### PR TITLE
fix exit_backend() race condition

### DIFF
--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -206,8 +206,9 @@ def _read_response(
     # One idea:
     # if ret["error_msg"]:
     #     raise Exception(ret["error_msg"])
-    if "error_msg" in ret and ret["error_msg"]:
-        print(ret["error_msg"])
+    # Another idea:
+    # if "error_msg" in ret and ret["error_msg"]:
+    #     print(ret["error_msg"])
 
     return ret
 

--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -206,9 +206,8 @@ def _read_response(
     # One idea:
     # if ret["error_msg"]:
     #     raise Exception(ret["error_msg"])
-    # Another idea:
-    # if "error_msg" in ret and ret["error_msg"]:
-    #     print(ret["error_msg"])
+    if "error_msg" in ret and ret["error_msg"]:
+        print(f'{ret["error_verb"]}: {ret["error_msg"]}')
 
     return ret
 

--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -1178,14 +1178,14 @@ def exit_backend() -> None:
     """
     This function exits the backend. Note that the API call will usually fail
     because the backend exits before returning a HTTP response so we suppress
-    the error. This is an old API function wrapper and will not be applicable to
-    the dockerized Watchful application instances.
+    the error. This is useful locally, for tests, and during development, but
+    not in dockerized Watchful application instances.
     """
 
     try:
         api("exit")
-    # We allowing passing this error as it is known.
-    except http.client.RemoteDisconnected:
+    # see docstring above
+    except (http.client.RemoteDisconnected, http.client.IncompleteRead):
         pass
 
 


### PR DESCRIPTION
Adds an exception type that was missing from `exit_backend()` (found by API fuzz testing by tests/0040*).