### PR TITLE
Implement column-wise enrichment pathway

### DIFF
--- a/examples/enrichment_intro.ipynb
+++ b/examples/enrichment_intro.ipynb
@@ -47,7 +47,7 @@
     {
      "data": {
       "text/plain": [
-       "'1.1.4'"
+       "'2.6.0'"
       ]
      },
      "execution_count": 2,
@@ -511,7 +511,9 @@
     "        pprint(enriched_row)\n",
     "        print(\"*\" * 80)\n",
     "\n",
-    "        return enriched_row"
+    "        return enriched_row\n",
+    "    \n",
+    "    enrich_row.order = \"row\""
    ]
   },
   {
@@ -677,6 +679,8 @@
       "    enricher\n",
       "\n",
       "DATA\n",
+      "    API_SUMMARY_HOOK_CALLBACK = None\n",
+      "    API_TIMEOUT_SEC = 600\n",
       "    ATTR_WRITER = None\n",
       "    BASE = 64\n",
       "    COMPRESSED = {0: '#', 1: '$', 2: '%', 3: '&', 4: \"'\", 5: '(', 6: ')', ...\n",
@@ -688,17 +692,18 @@
       "    Generator = typing.Generator\n",
       "    HOST = 'localhost'\n",
       "    IS_MULTIPROC = False\n",
-      "    Iterator = typing.Iterator\n",
       "    List = typing.List\n",
+      "    Literal = typing.Literal\n",
       "    MULTIPROC_CHUNKSIZE = None\n",
       "    NUMERALS = {0: '0', 1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6', 7:...\n",
       "    Optional = typing.Optional\n",
       "    PORT = '9002'\n",
+      "    SCHEME = 'http'\n",
       "    Tuple = typing.Tuple\n",
       "    Union = typing.Union\n",
       "\n",
       "VERSION\n",
-      "    1.1.4\n",
+      "    2.6.0\n",
       "\n",
       "\n"
      ]
@@ -760,16 +765,17 @@
       "     |      :meth:`enrich_row` to enrich our data row by row. This :meth:`__init__`\n",
       "     |      method needs to be implemented in your enricher class.\n",
       "     |  \n",
-      "     |  enrich_row(self, row: List[str]) -> List[List[Tuple[Union[List[Tuple[int]], Dict[str, List[str]], str, NoneType]]]]\n",
+      "     |  enrich_row(self, row: Dict[Union[str, NoneType], Union[str, NoneType]]) -> List[List[Tuple[Union[List[Tuple[int]], Dict[str, List[str]], str, NoneType]]]]\n",
       "     |      In this method, we use our variables from :attr:`self.enrichment_args`\n",
       "     |      initialized in :meth:`__init__` to enrich our data, row by row. The\n",
       "     |      return value is our enriched row. This :meth:`enrich_row` method needs\n",
       "     |      to be implemented in your enricher class.\n",
       "     |      \n",
-      "     |      :param row: An list of string values, one for each cell of the row; the\n",
+      "     |      :param row: A dictionary containing string keys as the column names and\n",
+      "     |          string values as the cell values, one for each cell of the row; the\n",
       "     |          rows are read using ``csv.reader`` on a csv file representing the\n",
       "     |          dataset.\n",
-      "     |      :type row: List[str]\n",
+      "     |      :type row: Dict[Optional[str], Optional[str]]\n",
       "     |      :return: A list of ``attributes.EnrichedCell`` containing the attributes\n",
       "     |          for each cell, for the entire row.\n",
       "     |      :rtype: List[attributes.EnrichedCell]\n",
@@ -803,7 +809,9 @@
       "     |  __abstractmethods__ = frozenset({'__init__', 'enrich_row'})\n",
       "\n",
       "DATA\n",
+      "    Dict = typing.Dict\n",
       "    List = typing.List\n",
+      "    Optional = typing.Optional\n",
       "\n",
       "\n"
      ]
@@ -812,14 +820,6 @@
    "source": [
     "help(w.enricher)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "72e9bb2e-8382-4852-b842-96b54bbc90d6",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This provides the basic column-wise enrichment pathway in the SDK; I'll have to create content in a notebook for column-wise enrichment guidance, but I think this should be able to go in first as it does not change the current row-wise enrichment feature while exposing the column-wise pathway.