### PR TITLE
Fixes issue when val is a bool

### DIFF
--- a/src/watchful/attributes.py
+++ b/src/watchful/attributes.py
@@ -297,7 +297,7 @@ def writer(output: io.TextIOWrapper, n_rows: int, n_cols: int) -> Callable:
                 # that many of them.
                 span_val.append(attrs[attr])
                 span_val.append(
-                    base64str([values[attr][val] if val else 0 for val in vals])
+                    base64str([values[attr][str(val)] if val else 0 for val in vals])
                 )
 
             cell.append(base64str(contig_spans(span)))


### PR DESCRIPTION
Fixes issue for when `val` is a bool. Needed to make this change (or an equivalent) to make boolean attribute value upload to work.