### PR TITLE
test: add initial attributes tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
 
 [tool.hatch.envs.default.scripts]
 test = [
-    "PYTHONPATH=src:$PYTHONPATH nosetests --with-coverage --cover-erase --cover-package=watchful --cover-html tests",
+    "PYTHONPATH=src:$PYTHONPATH nosetests -s --with-coverage --cover-erase --cover-package=watchful --cover-html tests",
 ]
 check = [
     "black --check --diff --config pyproject.toml src tests",
@@ -93,7 +93,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-################################################################################
 [tool.black]
 line-length = 80
 target-version = ['py310', 'py39', 'py38']

--- a/src/watchful/__init__.py
+++ b/src/watchful/__init__.py
@@ -58,7 +58,6 @@ from .client import (
     config_set,
     config,
     set_hub_url,
-    print_candidates,
     candidate_dicts,
     exit_backend,
     hub_api,
@@ -74,7 +73,6 @@ from .client import (
 from .attributes import (
     set_multiprocessing,
     set_multiproc_chunksize,
-    print_multiproc_params,
     base64,
     base64str,
     contig_spans,

--- a/src/watchful/attributes.py
+++ b/src/watchful/attributes.py
@@ -82,19 +82,11 @@ def set_multiproc_chunksize(multiproc_chunksize: int) -> None:
         MULTIPROC_CHUNKSIZE = multiproc_chunksize
 
 
-def print_multiproc_params() -> None:
-    """
-    This function prints the multiprocessing flag and the multiprocessing chunk
-    size for the data enrichment. This is still in internal alpha mode and is
-    not expected to be used by user.
-    """
-
-    print(
-        f"multiprocessing: {IS_MULTIPROC}, "
-        f"multiprocessing chunksize: {MULTIPROC_CHUNKSIZE}"
-    )
-
-
+# XXX: rockstar (1 May 2023) - This is not base64 encoding, so I'm not
+# sure why it's being named that. It might _look_ like base64 encoding
+# on the output, but it isn't. As it's not actually a standard format,
+# we now have to have parsers/generators in both rust and python. This
+# is not ideal.
 def base64(num: int) -> str:
     """
     This function takes in an integer value and returns its encoded string
@@ -105,7 +97,6 @@ def base64(num: int) -> str:
     :return: The encoded string value.
     :rtype: str
     """
-
     if num == 0:
         return NUMERALS[0]
 

--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -1430,25 +1430,6 @@ def set_hub_url(url: str) -> Optional[Dict]:
     return _read_response(response)
 
 
-def print_candidates(summary: Optional[Dict] = None) -> None:
-    """
-    This function retrieves and prints the column names and all the candidates.
-
-    :param summary: The dictionary of the HTTP response from a connection
-        request, defaults to None.
-    :type summary: Dict, optional
-    """
-
-    if summary is None:
-        summary = get()
-    print(
-        "\n".join(
-            [",".join(summary["field_names"])]
-            + list(map(lambda c: ",".join(c["fields"]), summary["candidates"]))
-        )
-    )
-
-
 def candidate_dicts(summary: Optional[Dict] = None) -> List[Dict[str, str]]:
     """
     This function retrieves and returns all the candidates, together with the

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,163 @@
+import unittest
+from unittest import mock
+
+from watchful import attributes
+
+
+class TestSetMultiprocessing(unittest.TestCase):
+    def setUp(self):
+        self.old_is_multiproc = attributes.IS_MULTIPROC
+        self.old_multiproc_chunksize = attributes.MULTIPROC_CHUNKSIZE
+
+    def tearDown(self):
+        attributes.IS_MULTIPROC = self.old_is_multiproc
+        attributes.MULTIPROC_CHUNKSIZE = self.old_multiproc_chunksize
+
+    def test_set_multiprocessing_true(self):
+        """Setting multiprocessing to true also sets a default chunk size"""
+        attributes.set_multiprocessing(True)
+
+        self.assertEqual(True, attributes.IS_MULTIPROC)
+        self.assertEqual(500, attributes.MULTIPROC_CHUNKSIZE)
+
+    def test_set_multiprocessing_false(self):
+        """Turning multiprocessing off sets chunk size to None as well"""
+        attributes.set_multiprocessing(False)
+
+        self.assertEqual(False, attributes.IS_MULTIPROC)
+        self.assertEqual(None, attributes.MULTIPROC_CHUNKSIZE)
+
+
+class TestSetMultiprocChunksize(unittest.TestCase):
+    def setUp(self):
+        self.old_is_multiproc = attributes.IS_MULTIPROC
+        self.old_multiproc_chunksize = attributes.MULTIPROC_CHUNKSIZE
+
+    def tearDown(self):
+        attributes.IS_MULTIPROC = self.old_is_multiproc
+        attributes.MULTIPROC_CHUNKSIZE = self.old_multiproc_chunksize
+
+    def test_set_multiproc_chunksize(self):
+        """The chunk size is updated to a new value."""
+        attributes.set_multiprocessing(True)
+
+        attributes.set_multiproc_chunksize(10)
+
+        self.assertEqual(10, attributes.MULTIPROC_CHUNKSIZE)
+
+    def test_set_multiproc_chunksize_less_than_zero(self):
+        """Chunk size cannot be set to zero."""
+        self.assertRaises(AssertionError, attributes.set_multiproc_chunksize, 0)
+
+    def test_set_multiproc_chunksize_not_multiproc(self):
+        """Setting chunk size when multiprocessing is off is a no-op"""
+        attributes.set_multiproc_chunksize(10)
+
+        self.assertEqual(None, attributes.MULTIPROC_CHUNKSIZE)
+
+
+class TestBase64(unittest.TestCase):
+    """Tests for watchful.attributes.base64
+
+    See the XXX comment in the source file. This function is named incorrectly,
+    and contains a mystery meat encoding.
+    """
+
+    def test_base64(self):
+        value = attributes.base64(55)
+
+        self.assertEqual("g", value)
+
+    def test_base64_zero(self):
+        value = attributes.base64(0)
+
+        self.assertEqual("0", value)
+
+
+class TestBase64Str(unittest.TestCase):
+    def test_base64str(self):
+        """An array of bytes is encoding as a comma-separated string"""
+        value = attributes.base64str([83, 55, 83, 2291947])
+
+        self.assertEqual("1C,g,1C,8_S[", value)
+
+    def test_base64str_with_compression(self):
+        """Repeated values use compression"""
+        value = attributes.base64str([83, 83, 83])
+
+        self.assertEqual("$1C1C1C", value)
+
+    def test_base64str_empty_list(self):
+        """An empty list makes an empty string"""
+        value = attributes.base64str([])
+
+        self.assertEqual("", value)
+
+
+class TestContigSpans(unittest.TestCase):
+    def test_contig_spans(self):
+        """An array of spans is encoded into a list of relative offsets"""
+        value = attributes.contig_spans([(0, 1), (2, 3), (4, 5)])
+
+        self.assertEqual([0, 1, 1, 1, 1, 1], value)
+
+
+class TestWriter(unittest.TestCase):
+    def test_writer(self):
+        """A writer factory produces a writer object to write attribute files"""
+        write_mock = mock.Mock()
+        expected_calls = [
+            mock.call("{"),
+            mock.call('"version"'),
+            mock.call(":"),
+            mock.call('"0.3"'),
+            mock.call(","),
+            mock.call('"rows"'),
+            mock.call(":"),
+            mock.call("2"),
+            mock.call(","),
+            mock.call('"cols"'),
+            mock.call(":"),
+            mock.call("2"),
+            mock.call("}"),
+            mock.call("\n"),
+            mock.call('["@"'),
+            mock.call(',"key"'),
+            mock.call("]"),
+            mock.call("\n"),
+            mock.call('["$"'),
+            mock.call(',"key"'),
+            mock.call(',"1"'),
+            mock.call("]"),
+            mock.call("\n"),
+            mock.call('["#110101"'),
+            mock.call(","),
+            mock.call('["an_name"'),
+            mock.call(",1"),
+            mock.call(',"#110"'),
+            mock.call("]"),
+            mock.call("]"),
+            mock.call("\n"),
+        ]
+
+        writer = attributes.writer(write_mock, 2, 2)
+        writer(
+            [
+                (
+                    [(1, 2), (2, 3), (3, 4)],
+                    {
+                        "key": [
+                            "1",
+                            1,
+                            None,
+                        ]
+                    },
+                    "an_name",
+                )
+            ]
+        )
+
+        self.assertEquals(
+            expected_calls,
+            write_mock.write.mock_calls,
+        )


### PR DESCRIPTION
This patch brings the total test coverage up to 30% as a result of adding some testing for some of the functions in `attributes.py` - its own coverage is now 37%.

Some of these functions will be difficult to test due to the quasi-concurrent nature of attributes. This not an interface that we should lean into at all, and is adding complexity (and, surely, bugs) where we don't need it.