### PR TITLE
Add filters to all steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout
       - install-hatch
-      - run: 
+      - run:
           command: hatch run test
   check:
     docker:
@@ -105,13 +105,22 @@ workflows:
   version: 2
   core:
     jobs:
-      - build
+      - build:
+        filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+[a-z]*\d*$/
       - test:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+[a-z]*\d*$/
       - check:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+[a-z]*\d*$/
       - publish:
           requires:
             - build


### PR DESCRIPTION
Updates all the steps to use a filter because `publish` and `send-slack-notification` have filters. See [this page](https://circleci.com/docs/workflows/#executing-workflows-for-a-git-tag) for more info