### PR TITLE
chore: cache dependencies in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,25 +27,46 @@ jobs:
       - image: circleci/python
     steps:
       - checkout
+      - restore_cache:
+          key: watchful-py-{{ checksum "pyproject.toml" }}
       - install-hatch
       - run:
           command: hatch build
+      - save_cache:
+          key: watchful-py-{{ checksum "pyproject.toml" }}
+          paths:
+            - ".hatch-env"
+            - "~/.cache/pip"
   test:
     docker:
       - image: circleci/python
     steps:
       - checkout
+      - restore_cache:
+          key: watchful-py-{{ checksum "pyproject.toml" }}
       - install-hatch
       - run:
           command: hatch run test
+      - save_cache:
+          key: watchful-py-{{ checksum "pyproject.toml" }}
+          paths:
+            - ".hatch-env"
+            - "~/.cache/pip"
   check:
     docker:
       - image: circleci/python
     steps:
       - checkout
+      - restore_cache:
+          key: watchful-py-{{ checksum "pyproject.toml" }}
       - install-hatch
       - run:
           command: hatch run check
+      - save_cache:
+          key: watchful-py-{{ checksum "pyproject.toml" }}
+          paths:
+            - ".hatch-env"
+            - "~/.cache/pip"
   publish:
     docker:
       - image: circleci/python

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 
 # Python
+.hatch-env/
 .ipynb_checkpoints/
 .pytest_cache/
 __pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ include = [
 ]
 
 [tool.hatch.envs.default]
+# CircleCI doesn't have a dynamic way of specifying paths
+# to be cached, so rather than just using the result of
+# `hatch env find`, we specify a static path and cache it.
+type = "virtual"
+path = ".hatch-env"
 dependencies = [
     "black",
     "mypy",


### PR DESCRIPTION
This patch adds the necessary functionality to cache dependencies in CircleCI. This isn't _strictly_ needed, but it would certainly speed up the CI process, particualarly in cases where we're working to push a change out quickly.