### PR TITLE
feat: add set_config/get_config to new Client

### DIFF
--- a/src/watchful/client2.py
+++ b/src/watchful/client2.py
@@ -275,16 +275,44 @@ class Client:
         """Label a candidate row."""
         return []
 
-    def set_config(self, key: str, value: str) -> None:
-        """Set a config value."""
+    def get_summary(self) -> Summary:
+        """Get the Watchful summary."""
+        response = self._session.post(
+            urljoin(self._root_url, "api"),
+            json={"verb": "nop"},
+            timeout=self.timeout,
+        )
+        return Summary(**response.json())
+
+    def set_config(self, key: str, value: str) -> typing.Dict:
+        """Set a config value.
+
+        This function returns the resulting config.
+        """
+        self._session.post(
+            urljoin(self._root_url, "config"),
+            json={"verb": "set", "key": key, "value": value},
+            timeout=self.timeout,
+        )
+
+        return self.get_config()
 
     # TODO: config should be a typed dataclass
     def get_config(self) -> typing.Dict:
         """Get the config."""
-        return {}
+        response = self._session.get(
+            urljoin(self._root_url, "config"), timeout=self.timeout
+        )
+        return response.json()
 
-    def set_hub_url(self, url) -> None:
+    def set_hub_url(self, url) -> typing.Dict[str, str]:
         """Set the hub url."""
+        return self.set_config("remote", url)
+
+    # Remote functionality
+    #
+    # The functions below interface with a "hub" instance, and thus
+    # require authentication.
 
     def login(self, email: str, password: str) -> None:
         """Log in to hub."""
@@ -306,12 +334,3 @@ class Client:
 
     def whoami(self, token: str) -> None:
         """Get login info from hub."""
-
-    def get_summary(self) -> Summary:
-        """Get the Watchful summary."""
-        response = self._session.post(
-            urljoin(self._root_url, "api"),
-            json={"verb": "nop"},
-            timeout=self.timeout,
-        )
-        return Summary(**response.json())

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -350,3 +350,37 @@ class TestClient(unittest.TestCase):
         summary = client.set_base_rate("my-class", 10)
 
         self.assertIn("my-class", summary.classes)
+
+    @responses.activate
+    def test_set_config(self):
+        """A configuration option is set."""
+        responses.add(
+            "POST",
+            urljoin(URL_ROOT, "config"),
+        )
+        responses.add(
+            "GET", urljoin(URL_ROOT, "config"), json={"username": "bobbyhill"}
+        )
+
+        client = Client(URL_ROOT)
+        config = client.set_config("username", "bobbyhill")
+
+        self.assertEqual({"username": "bobbyhill"}, config)
+
+    @responses.activate
+    def test_set_hub_url(self):
+        """A hub url is set."""
+        responses.add(
+            "POST",
+            urljoin(URL_ROOT, "config"),
+        )
+        responses.add(
+            "GET",
+            urljoin(URL_ROOT, "config"),
+            json={"remote": "http://watchful.example.com"},
+        )
+
+        client = Client(URL_ROOT)
+        config = client.set_hub_url("http://watchful.example.com")
+
+        self.assertEqual({"remote": "http://watchful.example.com"}, config)


### PR DESCRIPTION
This patch adds `set_config` and `get_config` functionality to the new `Client`.

Additionally, it implements `set_hub_url`, though it does it via a different interface than the original client. The original client
used `/set_hub_url`, which does some transformations and then does the equivalent of `set_config("remote", ...)` on the backend. The new `Client` interface opts to use `POST /config` instead of the old endpoint. The old endpoint, `POST  set_hub_url` should be deprecated and removed.