### PR TITLE
fix: don't trim the tag on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "New SDK Release! ${CIRCLE_TAG:1} :tada:",
+                    "text": "New SDK Release! ${CIRCLE_TAG} :tada:",
                     "emoji": true
                   }
                 },


### PR DESCRIPTION
When there was a `v` prefix on releases, we'd want to trim that off for notifying slack (this should have been a hint that it's not important). This patch fixes an issue where relevant information is now being trimmed off.