### PR TITLE
feat: add remote api functionality to new Client

### DIFF
--- a/src/watchful/client2.py
+++ b/src/watchful/client2.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import base64
 
 from dataclasses import dataclass, field
 import os
@@ -314,23 +315,103 @@ class Client:
     # The functions below interface with a "hub" instance, and thus
     # require authentication.
 
-    def login(self, email: str, password: str) -> None:
+    def login(
+        self, email: str, password: str
+    ) -> typing.Union[str, typing.Dict[str, str]]:
         """Log in to hub."""
+        credentials = base64.b64encode(f"{email}:{password}".encode()).decode(
+            "utf-8"
+        )
+        # Remote functions return a summary. In this case, we'll ignore the
+        # summary, as it's mostly irrelevant for what we need.
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={"verb": "login"},
+            headers={"Authorization": f"Basic {credentials}"},
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
 
-    def publish(self, token: str) -> None:
+    # XXX: rockstar (22 May 2023) - The following functions all required a
+    # token. It's likely that we should just capture the remote token somewhere
+    # and re-use it as part of the session.
+    def publish(self, token: str) -> typing.Union[str, typing.Dict[str, str]]:
         """Publish to hub."""
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={"verb": "publish"},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
 
-    def fetch(self, token: str) -> None:
+    def fetch(self, token: str) -> typing.Union[str, typing.Dict[str, str]]:
         """Fetch data from hub."""
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={"verb": "fetch"},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
 
-    def pull(self, token: str) -> None:
+    def pull(self, token: str) -> typing.Union[str, typing.Dict[str, str]]:
         """Pull data from hub."""
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={"verb": "pull"},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
 
-    def push(self, token: str) -> None:
+    def push(self, token: str) -> typing.Union[str, typing.Dict[str, str]]:
         """Push data to hub."""
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={"verb": "push"},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
 
-    def peek(self, token: str) -> None:
+    def peek(self, token: str) -> typing.Union[str, typing.Dict[str, str]]:
         """Peek at data in hub."""
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={"verb": "peek"},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
 
-    def whoami(self, token: str) -> None:
+    def whoami(self, token: str) -> typing.Union[str, typing.Dict[str, str]]:
         """Get login info from hub."""
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={"verb": "whoami"},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -384,3 +384,100 @@ class TestClient(unittest.TestCase):
         config = client.set_hub_url("http://watchful.example.com")
 
         self.assertEqual({"remote": "http://watchful.example.com"}, config)
+
+    @responses.activate
+    def test_login(self):
+        """A user can log in to a remote hub."""
+        responses.add(
+            responses.POST, urljoin(URL_ROOT, "remote"), body="myToken"
+        )
+
+        client = Client(URL_ROOT)
+        data = client.login("myUserName", "NotAVerySecurePassword")
+
+        self.assertTrue(
+            responses.assert_call_count(urljoin(URL_ROOT, "remote"), 1)
+        )
+        self.assertEqual(data, "myToken")
+
+    @responses.activate
+    def test_publish(self):
+        """Project data is published to a hub."""
+        responses.add(responses.POST, urljoin(URL_ROOT, "remote"), body="OK")
+
+        client = Client(URL_ROOT)
+        data = client.publish("myToken")
+
+        self.assertTrue(
+            responses.assert_call_count(urljoin(URL_ROOT, "remote"), 1)
+        )
+        self.assertEqual(data, "OK")
+
+    @responses.activate
+    def test_fetch(self):
+        """Project state is fetched from a hub."""
+        responses.add(responses.POST, urljoin(URL_ROOT, "remote"), body="OK")
+
+        client = Client(URL_ROOT)
+        data = client.fetch("myToken")
+
+        self.assertTrue(
+            responses.assert_call_count(urljoin(URL_ROOT, "remote"), 1)
+        )
+        self.assertEqual(data, "OK")
+
+    @responses.activate
+    def test_pull(self):
+        """Project data is pulled from a hub."""
+        responses.add(responses.POST, urljoin(URL_ROOT, "remote"), body="OK")
+
+        client = Client(URL_ROOT)
+        data = client.pull("myToken")
+
+        self.assertTrue(
+            responses.assert_call_count(urljoin(URL_ROOT, "remote"), 1)
+        )
+        self.assertEqual(data, "OK")
+
+    @responses.activate
+    def test_push(self):
+        """Project data is pushed to a hub."""
+        responses.add(responses.POST, urljoin(URL_ROOT, "remote"), body="OK")
+
+        client = Client(URL_ROOT)
+        data = client.push("myToken")
+
+        self.assertTrue(
+            responses.assert_call_count(urljoin(URL_ROOT, "remote"), 1)
+        )
+        self.assertEqual(data, "OK")
+
+    @responses.activate
+    def test_peek(self):
+        """Hub data can be viewed without a pull."""
+        responses.add(
+            responses.POST,
+            urljoin(URL_ROOT, "remote"),
+            body="OK",
+        )
+
+        client = Client(URL_ROOT)
+        data = client.peek("myToken")
+
+        self.assertTrue(
+            responses.assert_call_count(urljoin(URL_ROOT, "remote"), 1)
+        )
+        self.assertEqual(data, "OK")
+
+    @responses.activate
+    def test_whoami(self):
+        """A user can find out who they are logged in as."""
+        responses.add(responses.POST, urljoin(URL_ROOT, "remote"), body="OK")
+
+        client = Client(URL_ROOT)
+        data = client.whoami("myToken")
+
+        self.assertTrue(
+            responses.assert_call_count(urljoin(URL_ROOT, "remote"), 1)
+        )
+        self.assertEqual(data, "OK")


### PR DESCRIPTION
This patch implement the functionality that interacts with a hub instance. The remote api is a little shaky here, as sometimes it will return json and sometimes it will return a plain string (which the server side considers a valid json value, and python does not).