### PR TITLE
feat: implement create_class/delete_class

### DIFF
--- a/src/watchful/client2.py
+++ b/src/watchful/client2.py
@@ -11,6 +11,7 @@ import uuid
 import requests
 
 from watchful.__about__ import __version__
+from watchful import types
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -222,15 +223,36 @@ class Client:
         )
 
     def create_class(
-        self, classification: str, class_type: str = "ftc"
-    ) -> None:
+        self,
+        name: str,
+        class_type: types.ClassificationType = types.ClassificationType.FTC,
+    ) -> Summary:
         """Add a classification."""
+        response = self._session.post(
+            urljoin(self._root_url, "api"),
+            json={
+                "verb": "class",
+                "name": name,
+                "class_type": class_type.value,
+            },
+        )
+        return Summary(**response.json())
 
     def delete_class(
         self,
-        classification: str,
-    ) -> None:
+        name: str,
+    ) -> Summary:
         """Delete a classifier."""
+        response = self._session.post(
+            urljoin(self._root_url, "api"),
+            json={
+                "verb": "delete",
+                # XXX: rockstar (22 May 2023) - This is named differently
+                # than "name" from `create_class`.
+                "class_name": name,
+            },
+        )
+        return Summary(**response.json())
 
     def query(self, query: str, page: int = 0) -> None:
         """Execute a query."""

--- a/src/watchful/types.py
+++ b/src/watchful/types.py
@@ -1,0 +1,11 @@
+import enum
+
+
+# XXX: rockstar (22 May 2023) - This enum could
+# be changed to a StrEnum and can use enum.auto()
+# once we only support python 3.11+
+class ClassificationType(enum.Enum):
+    """The supported text classifaction types in Watchful."""
+
+    FTC = "ftc"
+    NER = "ner"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -264,6 +264,123 @@ class TestClient(unittest.TestCase):
         )
 
     @responses.activate
+    def test_create_class(self):
+        """A text class is created."""
+        responses.add(
+            responses.POST,
+            urljoin(URL_ROOT, "api"),
+            json={
+                "project_id": "abc123",
+                "title": "my new project",
+                "datasets": ["12"],
+                "auto_complete": "",
+                "cand_seq_full": "",
+                "cand_seq_prefix": "",
+                "candidates": [],
+                "classes": "",
+                "column_flags": {"inferenceable": [True, False, False]},
+                "disagreements": "",
+                "enrichment_tasks": "",
+                "error_msg": None,
+                "error_verb": None,
+                "export_preview": None,
+                "exports": [],
+                "field_names": [],
+                "hand_labels": [],
+                "hinters": [],
+                "is_shared": False,
+                "messages": [],
+                "n_candidates": "",
+                "n_handlabels": "",
+                "ner_hl_text": "",
+                "notifications": "",
+                "precision_candidate": "",
+                "project_config": "",
+                "published_title": "",
+                "pull_actions": "",
+                "push_actions": "",
+                "query": "",
+                "query_breakdown": "",
+                "query_completed": "",
+                "query_end": "",
+                "query_examined": "",
+                "query_full_rows": "",
+                "query_history": "",
+                "query_hit_count": "",
+                "query_page": "",
+                "selected_class": "",
+                "selections": "",
+                "show_notification_badge": "",
+                "state_seq": "",
+                "status": "",
+                "suggestion": "",
+                "suggestions": "",
+                "unlabeled_candidate": "",
+            },
+        )
+        client = Client(URL_ROOT)
+        client.create_class("myClass")
+
+    @responses.activate
+    def test_delete_class(self):
+        """A text class is deleted."""
+        responses.add(
+            responses.POST,
+            urljoin(URL_ROOT, "api"),
+            json={
+                "project_id": "abc123",
+                "title": "my new project",
+                "datasets": ["12"],
+                "auto_complete": "",
+                "cand_seq_full": "",
+                "cand_seq_prefix": "",
+                "candidates": [],
+                "classes": "",
+                "column_flags": {"inferenceable": [True, False, False]},
+                "disagreements": "",
+                "enrichment_tasks": "",
+                "error_msg": None,
+                "error_verb": None,
+                "export_preview": None,
+                "exports": [],
+                "field_names": [],
+                "hand_labels": [],
+                "hinters": [],
+                "is_shared": False,
+                "messages": [],
+                "n_candidates": "",
+                "n_handlabels": "",
+                "ner_hl_text": "",
+                "notifications": "",
+                "precision_candidate": "",
+                "project_config": "",
+                "published_title": "",
+                "pull_actions": "",
+                "push_actions": "",
+                "query": "",
+                "query_breakdown": "",
+                "query_completed": "",
+                "query_end": "",
+                "query_examined": "",
+                "query_full_rows": "",
+                "query_history": "",
+                "query_hit_count": "",
+                "query_page": "",
+                "selected_class": "",
+                "selections": "",
+                "show_notification_badge": "",
+                "state_seq": "",
+                "status": "",
+                "suggestion": "",
+                "suggestions": "",
+                "unlabeled_candidate": "",
+            },
+        )
+
+        client = Client(URL_ROOT)
+        client.delete_class("myClass")
+
+    @responses.activate
     def test_set_base_rate(self):
         """The base rate for a class is set."""
         responses.add(


### PR DESCRIPTION
This patch implements the `create_class` and `delete_class` functionality for the new `Client` interface.