### PR TITLE
chore: save mypy and ruff caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
           key: watchful-py-{{ checksum "pyproject.toml" }}
           paths:
             - ".hatch-env"
+            - ".mypy_cache"
+            - ".ruff_cache"
             - "~/.cache/pip"
   publish:
     docker:


### PR DESCRIPTION
The `check` step of CI takes the longest, and it does so because `ruff` and `mypy` both have to start from scratch in their analysis. This patch keeps the caches from both commands so that they can be reused in the next run. This sholud make the the `check` step much quicker.