### PR TITLE
Add support for enrichable column flags

### DIFF
--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -597,7 +597,7 @@ def records(csv_: str) -> Optional[Dict]:
 
 def set_column_flag(
     columns: Optional[List[str]] = None,
-    flag: Literal["inferenceable"] = "inferenceable",
+    flag: Literal["inferenceable", "enrichable"] = "inferenceable",
     pos_sense: bool = True,
 ) -> Optional[Dict]:
     """
@@ -606,8 +606,8 @@ def set_column_flag(
     ``True`` and all other columns will be set to ``False``. A helper to
     indicate all available columns as given is to omit ``columns``.
 
-    :param flag: The flag to be set; "inferenceable" is currently the only
-        supported flag.
+    :param flag: The flag to be set; "inferenceable" and "enrichable" are the
+        only supported flags.
     :type flag: str, optional
     :param columns: A list of column names specifying whether the flag should
         be set.
@@ -646,7 +646,7 @@ def set_column_flag(
 
 def ignore_column_flag(
     columns: Optional[List[str]] = None,
-    flag: Literal["inferenceable"] = "inferenceable",
+    flag: Literal["inferenceable", "enrichable"] = "inferenceable",
 ) -> Optional[Dict]:
     """
     This function sets a flag for each of the columns of the dataset in the
@@ -654,8 +654,8 @@ def ignore_column_flag(
     other columns will be set to ``True``. A helper to indicate all available
     columns as given is to omit ``columns``.
 
-    :param flag: The flag to be set; "inferenceable" is currently the only
-        supported flag.
+    :param flag: The flag to be set; "inferenceable" and "enrichable" are the
+        only supported flags.
     :type flag: str, optional
     :param columns: A list of column names specifying whether the flag should
         be set to ``False``.

--- a/src/watchful/client2.py
+++ b/src/watchful/client2.py
@@ -198,13 +198,12 @@ class Client:
     def flag_columns(
         self,
         columns: typing.List[bool],
-        flag: typing.Literal["inferenceable"] = "inferenceable",
+        flag: typing.Literal["inferenceable", "enrichable"],
     ) -> Summary:
         """Toggle flags for columns."""
-        if flag != "inferenceable":
-            raise ValueError(
-                "Only the 'inferenceable' flag is supported at this time."
-            )
+        flags = ["inferenceable", "enrichable"]
+        if flag not in flags:
+            raise ValueError("Flag must be 'inferenceable' or 'enrichable'")
 
         self._session.post(
             urljoin(self._root_url, "api"),

--- a/src/watchful/types.py
+++ b/src/watchful/types.py
@@ -10,6 +10,3 @@ class ClassificationType(enum.Enum):
 
     FTC = "ftc"
     NER = "ner"
-
-
-SupportedFlags: TypeAlias = Literal["inferenceable", "enrichable"]

--- a/src/watchful/types.py
+++ b/src/watchful/types.py
@@ -1,5 +1,4 @@
 import enum
-from typing import TypeAlias, Literal
 
 
 # XXX: rockstar (22 May 2023) - This enum could

--- a/src/watchful/types.py
+++ b/src/watchful/types.py
@@ -1,4 +1,5 @@
 import enum
+from typing import TypeAlias, Literal
 
 
 # XXX: rockstar (22 May 2023) - This enum could
@@ -9,3 +10,6 @@ class ClassificationType(enum.Enum):
 
     FTC = "ftc"
     NER = "ner"
+
+
+SupportedFlags: TypeAlias = Literal["inferenceable", "enrichable"]

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -195,7 +195,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual("my new project", summary.title)
 
     @responses.activate
-    def test_flag_columns(self):
+    def test_flag_inference_columns(self):
         """Column flags are set."""
         responses.add(
             "POST",
@@ -252,12 +252,74 @@ class TestClient(unittest.TestCase):
 
         flags = [True, False, False]
         client = Client(URL_ROOT)
-        summary = client.flag_columns(flags)
+        summary = client.flag_columns(flags, "inferenceable")
 
         self.assertEqual({"inferenceable": flags}, summary.column_flags)
 
-    def test_flag_columns_not_inferenceable(self):
-        """Flags not explicitly titled "inferenceable" are not allowed."""
+    @responses.activate
+    def test_flag_enrich_columns(self):
+        """Column flags are set."""
+        responses.add(
+            "POST",
+            urljoin(URL_ROOT, "api"),
+            json={
+                "project_id": "abc123",
+                "title": "my new project",
+                "datasets": ["12"],
+                "auto_complete": "",
+                "cand_seq_full": "",
+                "cand_seq_prefix": "",
+                "candidates": [],
+                "classes": "",
+                "column_flags": {"enrichable": [True, False, True]},
+                "disagreements": "",
+                "enrichment_tasks": "",
+                "error_msg": None,
+                "error_verb": None,
+                "export_preview": None,
+                "exports": [],
+                "field_names": [],
+                "hand_labels": [],
+                "hinters": [],
+                "is_shared": False,
+                "messages": [],
+                "n_candidates": "",
+                "n_handlabels": "",
+                "ner_hl_text": "",
+                "notifications": "",
+                "precision_candidate": "",
+                "project_config": "",
+                "published_title": "",
+                "pull_actions": "",
+                "push_actions": "",
+                "query": "",
+                "query_breakdown": "",
+                "query_completed": "",
+                "query_end": "",
+                "query_examined": "",
+                "query_full_rows": "",
+                "query_history": "",
+                "query_hit_count": "",
+                "query_page": "",
+                "selected_class": "",
+                "selections": "",
+                "show_notification_badge": "",
+                "state_seq": "",
+                "status": "",
+                "suggestion": "",
+                "suggestions": "",
+                "unlabeled_candidate": "",
+            },
+        )
+
+        flags = [True, False, True]
+        client = Client(URL_ROOT)
+        summary = client.flag_columns(flags, "enrichable")
+
+        self.assertEqual({"enrichable": flags}, summary.column_flags)
+
+    def test_flag_columns_not_valid(self):
+        """Only "inferencable" and "enrichable" are valid flags."""
         client = Client(URL_ROOT)
 
         self.assertRaises(


### PR DESCRIPTION
This PR adds support for the `enrichable` column flag by mostly copying/extending the support that was in place for the `inferenceable` flag.

Closes [sc-10980](https://app.shortcut.com/watchful/story/10980/update-python-lib-to-support-enrichable)