### PR TITLE
Bump minor version

### DIFF
--- a/src/watchful/__about__.py
+++ b/src/watchful/__about__.py
@@ -1,3 +1,3 @@
 """Package meta information for watchful."""
 
-__version__ = "3.4.2"
+__version__ = "3.5.1"


### PR DESCRIPTION
Bump to v3.5.1. We previously tagged v3.5.0 by mistake and later yanked that. To avoid conflicts and issues, we'll skip that and go straight to v3.5.1