### PR TITLE
Revert lambda change

### DIFF
--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -1008,9 +1008,11 @@ def hint(name: str, offset: int, values: List[bool]) -> Optional[Dict]:
     TODO: Come up with a better streaming Python API here.
     """
 
-    values = list(map(lambda x: x, values))
+    cast_values = list(map(lambda x: int(x), values))
 
-    return _assert_success(api("hint", name=name, offset=offset, values=values))
+    return _assert_success(
+        api("hint", name=name, offset=offset, values=cast_values)
+    )
 
 
 def apply_hints(name: str) -> Optional[Dict]:


### PR DESCRIPTION
In the main app, the `hint` verb expects the `values` list to be integers. This patch adds the casting back (was in there as late as v3.1.0).

The change to no longer cast the booleans and just send them was never caught because the app stopped taking version upgrades as of v3.1.0 and, to our knowledge, no one is actually using this except the `tests/0016_external_hint` test in the main app.