### PR TITLE
chore: add requests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Watchful API for Interacting with Watchful Environment"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Watchful", email = "engineering@watchful.io" },
     { name = "Inc." },
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "chardet>=5.1.0",
     "psutil>=5.9.2",
+    "requests>=2.23.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`watchful` has a dependency on `requests` that we never included in our python dependency. This patch remedies that.

Additionally, the next version of watchful-py will require a version of python that is still being maintained.