### PR TITLE
WF-164 correct encoding procedure

### DIFF
--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -1005,14 +1005,12 @@ def export_stream(
     :rtype: requests.models.Response
     """
 
-    _content_type = urllib.parse.quote_plus(content_type)
-    _mode = urllib.parse.quote_plus(mode)
     if token is None:
         token = TOKEN
 
     query = {
-        "content-type": _content_type,
-        "mode": _mode,
+        "content-type": content_type,
+        "mode": mode,
         "token": token,
     }
     if filename is not None:

--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -12,7 +12,6 @@ import socket
 import subprocess
 import sys
 import time
-import urllib
 from typing import (
     Any,
     Callable,


### PR DESCRIPTION
WF-164

#359 introduced an issue where we were encoding the `mode` and `content-type` parameters twice. This PR fixes that issue