### PR TITLE
Add proxy method to register user using remote api from app

### DIFF
--- a/src/watchful/__init__.py
+++ b/src/watchful/__init__.py
@@ -1,4 +1,5 @@
 """Watchful python library"""
+
 # ruff: noqa: F401
 
 # We need to be careful of unintended overriding, and also a deeper

--- a/src/watchful/attributes.py
+++ b/src/watchful/attributes.py
@@ -1,6 +1,7 @@
 """
 This script provides the functions required for data enrichment.
 """
+
 # mypy: ignore-errors
 
 import csv

--- a/src/watchful/client.py
+++ b/src/watchful/client.py
@@ -1426,6 +1426,33 @@ def hub_api(verb: str, token: str) -> Optional[Dict]:
     return _assert_success(_read_response(response))
 
 
+def hub_api_with_data(token: str, data: Dict) -> Optional[Dict]:
+    """
+    This is a convenience function for collaboration API calls with Watchful;
+    made up of a verb, a token and optional keyword arguments.
+
+    :param verb: The verb for the hub API.
+    :type verb: str
+    :param verb: The user's auth token.
+    :type token: str
+    :param data: The data to be sent to the hub API.
+    :type data: Dict
+    :return: The dictionary of the HTTP response from the connection request.
+    :rtype: Dict, optional
+    """
+
+    headers = {"Content-Type": "application/json"}
+    headers.update({"Authorization": "Bearer " + token})
+    response = request(
+        "POST",
+        "/remote",
+        data=json.dumps(data),
+        headers=headers,
+        timeout=API_TIMEOUT_SEC,
+    )
+    return _assert_success(_read_response(response))
+
+
 def login(email: str, password: str) -> Optional[Dict]:
     """
     This function performs login with the email and password with Watchful hub.
@@ -1533,6 +1560,36 @@ def whoami(token: str) -> Optional[Dict]:
     """
 
     return hub_api("whoami", token)
+
+
+def register(
+    token: str, username: str, email: str, password: str, role: str
+) -> Optional[Dict]:
+    """
+    This function performs register with Watchful hub.
+
+    :param username: The user's username.
+    :type username: str
+    :param email: The user's email.
+    :type email: str
+    :param password: The user's password.
+    :type password: str
+    :param role: The user's role.
+    :type role: str
+    :return: The dictionary of the HTTP response from the connection request.
+    :rtype: Dict, optional
+    """
+
+    return hub_api_with_data(
+        token,
+        {
+            "verb": "register",
+            "username": username,
+            "email": email,
+            "password": password,
+            "role": role,
+        },
+    )
 
 
 class WatchfulAppInstanceError(Exception):

--- a/src/watchful/client2.py
+++ b/src/watchful/client2.py
@@ -515,23 +515,3 @@ class Client:
             return response.json()
         except ValueError:
             return response.text
-
-    def register(
-        self, username: str, email: str, password: str, role: str
-    ) -> typing.Union[str, str]:
-        """Register with hub."""
-        response = self._session.post(
-            urljoin(self._root_url, "remote"),
-            json={
-                "verb": "register",
-                "username": username,
-                "email": email,
-                "password": password,
-                "role": role,
-            },
-            timeout=self.timeout,
-        )
-        try:
-            return response.json()
-        except ValueError:
-            return response.text

--- a/src/watchful/client2.py
+++ b/src/watchful/client2.py
@@ -515,3 +515,23 @@ class Client:
             return response.json()
         except ValueError:
             return response.text
+
+    def register(
+        self, username: str, email: str, password: str, role: str
+    ) -> typing.Union[str, str]:
+        """Register with hub."""
+        response = self._session.post(
+            urljoin(self._root_url, "remote"),
+            json={
+                "verb": "register",
+                "username": username,
+                "email": email,
+                "password": password,
+                "role": role,
+            },
+            timeout=self.timeout,
+        )
+        try:
+            return response.json()
+        except ValueError:
+            return response.text

--- a/src/watchful/enrich.py
+++ b/src/watchful/enrich.py
@@ -2,6 +2,7 @@
 This script is run on the Python command line to execute data enrichment. If a
 custom enricher is used, then the :func:`enrich_dataset` function is used.
 """
+
 ################################################################################
 
 

--- a/src/watchful/enricher.py
+++ b/src/watchful/enricher.py
@@ -5,6 +5,7 @@ custom data enrichment functions and models within :meth:`enrich_fn`. Refer to
 https://github.com/Watchfulio/watchful-py/blob/main/examples/enrichment_intro.ipynb
 for a tutorial on how to implement your custom enricher class.
 """
+
 ################################################################################
 
 


### PR DESCRIPTION
[WF-141](https://watchful.atlassian.net/browse/WF-141)

This PR adds register method to the Client class, so that it can be used to register user in the integration tests. It takes in 

1. verb
2. username
3. email
4. password
5. role

and sends back a Json<str, str>

[WF-141]: https://watchful.atlassian.net/browse/WF-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ